### PR TITLE
Added components for persistent storage

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -14,13 +14,15 @@ jobs:
           DOMAIN=$(jq -r '.domain' custom_components/abc_council_bin_collection/manifest.json)
           if [[ "$DOMAIN" != "abc_council_bin_collection" ]]; then
             echo "Error: Incorrect domain in manifest.json"
+            echo "Extracted value: '$DOMAIN'"
             exit 1
           fi
 
       - name: Check const.py
         run: |
-          DOMAIN=$(grep -oP '(?<=DOMAIN = ")[^"]+' custom_components/abc_council_bin_collection/const.py)
+          DOMAIN=$(grep -oP '(?<=DOMAIN: str = ")[^"]+' custom_components/abc_council_bin_collection/const.py)
           if [[ "$DOMAIN" != "abc_council_bin_collection" ]]; then
             echo "Error: Incorrect DOMAIN in const.py"
+            echo "Extracted value: '$DOMAIN'"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ When the integration is added, the **Configure** button offer additional options
 
 For further control if you wish to use the dates; an entity has been created for each collection type with the state being the next collection date, then the subsequent dates being placed within the state attributes under **all_dates**.
 
+A button entity has also been created which allows you to clear persistent storage for all calendar events created.
+
 ## Note
 
-- If **Create Calendar Events** is ticked and then either the integration or Home Assistant instance is restarted, it will create the calendar events again until a suitable persistant solution is put in place.
-- Upon saving the Configure options it will reload the integration.
+- If calendar events aren't automatically created after ticking option to create calendar events, just reload the integration.

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,0 +1,42 @@
+alias: Notify - Bin Collection Reminder
+description: ""
+triggers:
+  - at: "20:00:00"
+    trigger: time
+conditions:
+  - condition: template
+    value_template: >
+      {% set tomorrow = (now() + timedelta(days=1)).strftime('%Y-%m-%d') %} {{
+      states('sensor.domestic_collections') == tomorrow
+         or states('sensor.recycling_collections') == tomorrow
+         or states('sensor.garden_food_collections') == tomorrow }}
+actions:
+  - data:
+      title: Bin collection tomorrow
+      message: >
+        {%- set tomorrow = (now() + timedelta(days=1)).strftime('%Y-%m-%d') -%}
+        {%- set bins_to_collect = [] -%} {%- if
+        states('sensor.domestic_collections') == tomorrow -%}
+          {%- set bins_to_collect = bins_to_collect + ["Blue"] -%}
+        {%- endif -%} {%- if states('sensor.recycling_collections') == tomorrow
+        -%}
+          {%- set bins_to_collect = bins_to_collect + ["Green"] -%}
+        {%- endif -%} {%- if states('sensor.garden_food_collections') ==
+        tomorrow -%}
+          {%- set bins_to_collect = bins_to_collect + ["Brown"] -%}
+        {%- endif -%} {%- if bins_to_collect | length == 1 -%}
+          Put out {{ bins_to_collect[0] }} bin.
+        {%- elif bins_to_collect | length > 1 -%}
+          {%- set first_parts = bins_to_collect[0:-1] -%}
+          {%- set last = bins_to_collect[-1] -%}
+          Put out {{ first_parts | join(', ') }} and {{ last }} bins.
+        {%- endif -%}
+      data:
+        persistent: true
+        ttl: 0
+        priority: high
+        channel: alarm_stream
+        actions:
+          - action: BIN_DONE
+            title: Task Complete
+    action: notify.mobile_app_phone_example

--- a/custom_components/abc_council_bin_collection/__init__.py
+++ b/custom_components/abc_council_bin_collection/__init__.py
@@ -1,63 +1,94 @@
-from datetime import timedelta
 import logging
 
+from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL
+from .coordinator import BinCollectionDataUpdateCoordinator
+from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .coordinator import BinCollectionDataUpdateCoordinator
-from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL
-
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor"]
+PLATFORMS = ["sensor", "button"]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    if not entry.data.get("address"):
-        _LOGGER.error("Missing address in entry data!")
-        return False  # Prevent setup if no valid address is found
+def _extract_options(entry: ConfigEntry) -> tuple[str, timedelta, dict]:
+    """Extract and validate options from the config entry"""
 
-    address = entry.data["address"]
-    
-    options = {**entry.options} if entry.options else {}
-
-    update_interval_hours = options.get("update_interval", DEFAULT_UPDATE_INTERVAL)
-    update_interval = timedelta(hours=update_interval_hours)
-
-    create_calendar_events = options.get("create_calendar_events", False)
-    calendar_entity = options.get("calendar_entity", "").strip()
-
-    # This dictionary is used ONLY for calendar event creation.
+    address = entry.data.get("address")
+    options = entry.options if entry.options else {}
+    update_interval = timedelta(hours=options.get("update_interval", DEFAULT_UPDATE_INTERVAL))
     event_summaries = {
         "Domestic Collections": options.get("summary_domestic", "Domestic Collections"),
         "Recycling Collections": options.get("summary_recycling", "Recycling Collections"),
         "Garden/Food Collections": options.get("summary_garden_food", "Garden/Food Collections"),
     }
 
-    _LOGGER.debug("Setting up Bin Collection with:")
-    _LOGGER.debug("Address: %s", address)
-    _LOGGER.debug("Update Interval: %s hours", update_interval_hours)
-    _LOGGER.debug("Options: %s", options)
+    return address, update_interval, event_summaries
 
-    coordinator = BinCollectionDataUpdateCoordinator(
-        hass,
-        address=address,
-        update_interval=update_interval,
-        create_calendar_events=create_calendar_events,
-        calendar_entity=calendar_entity,
-        event_summaries=event_summaries,
-    )
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up the ABC Council Bin Collection integration from a config entry"""
 
-    await coordinator.async_refresh()
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    _LOGGER.info("ABC Council Bin Collection integration starting: %s", entry.entry_id)
+
+    # Ensure DOMAIN storage is initialized
+    hass.data.setdefault(DOMAIN, {})
+
+    address, update_interval, event_summaries = _extract_options(entry)
+    if not address:
+        _LOGGER.error("Missing address in entry data - reinstall integration.")
+        return False
+
+    _LOGGER.debug("Setting up integration with address: %s, update_interval: %s, options: %s", address, update_interval, entry.options)
+
+    try:
+        # Initialize coordinator
+        coordinator = BinCollectionDataUpdateCoordinator(
+            hass=hass,
+            address=address,
+            update_interval=update_interval,
+            create_calendar_events=entry.options.get("create_calendar_events", False),
+            calendar_entity=entry.options.get("calendar_entity", "").strip(),
+            event_summaries=event_summaries,
+        )
+        await coordinator.load_stored_events()
+        coordinator.data = await coordinator._async_update_data()
+    except Exception as err:
+        _LOGGER.exception("Error setting up coordinator: %s", err)
+        return False
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _LOGGER.info("ABC Council Bin Collection integration setup successfully: %s", entry.entry_id)
+    
     return True
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    _LOGGER.debug("Unloading entry: %s", entry.entry_id)
+    """Unload a config entry"""
 
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+    _LOGGER.info("ABC Council Bin Collection unloading: %s", entry.entry_id)
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+
+    if unload_ok:
+        _LOGGER.info("ABC Council Bin Collection unloaded successfully: %s", entry.entry_id)
+    else:
+        _LOGGER.warning("ABC Council Bin Collection failed to unload: %s", entry.entry_id)
 
     return unload_ok
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Remove a config entry and clear stored persistent data"""
+
+    coordinator = hass.data[DOMAIN].get(entry.entry_id)
+    if coordinator and hasattr(coordinator, "storage"):
+        _LOGGER.debug("Storage found for integration %s, clearing data...", entry.entry_id)
+        try:
+            await coordinator.storage.clear_data()
+        except Exception as err:
+            _LOGGER.exception("Error clearing storage for integration %s: %s", entry.entry_id, err)
+    else:
+        _LOGGER.info("Storage instance not found for entry %s, possibly removed too early or none exist, this is ok.", entry.entry_id)
+    
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+
+    _LOGGER.info("ABC Council Bin Collection successfully removed entry %s from hass.data", entry.entry_id)

--- a/custom_components/abc_council_bin_collection/button.py
+++ b/custom_components/abc_council_bin_collection/button.py
@@ -1,0 +1,60 @@
+"""
+Button platform for ABC Council Bin Collection integration.
+
+Provides a button entity that, when pressed, clears persistent bin collection events.
+"""
+
+import logging
+
+from .const import DOMAIN, DEVICE_NAME, DEVICE_MANUFACTURER, DEVICE_MODEL
+from .storage import BinCollectionStorage
+from homeassistant.components.button import ButtonEntity
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    """Set up the Clear Bin Events button entity."""
+    _LOGGER.debug("Setting up Clear Bin Events button entity...")
+
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if not coordinator:
+        _LOGGER.error("Coordinator not found for entry_id: %s", entry.entry_id)
+        return
+
+    async_add_entities([ClearBinEventsButton(coordinator.storage, entry.entry_id, coordinator.address)])
+    _LOGGER.debug("Clear Bin Events button entity successfully registered.")
+
+class ClearBinEventsButton(ButtonEntity):
+    """Clear events button entity"""
+
+    def __init__(self, storage: BinCollectionStorage, entry_id: str, address: str) -> None:
+        """Initialize the button entity"""
+
+        self._storage = storage
+        self._entry_id = entry_id
+        self._address = address
+        self._attr_name = "Clear Bin Events" #translation
+        self._attr_icon = "mdi:trash-can"
+        self._attr_unique_id = f"clear_bin_events_{entry_id}"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._address)},
+            "name": DEVICE_NAME,
+            "manufacturer": DEVICE_MANUFACTURER,
+            "model": DEVICE_MODEL,
+        }
+
+    async def async_press(self) -> None:
+        """Action to occur upon button trigger"""
+
+        try:
+            _LOGGER.info("Clearing all stored bin collection events...")
+            await self._storage.clear_data()
+            _LOGGER.info("Bin collection events successfully cleared.")
+        except Exception as err:
+            _LOGGER.exception("Failed to clear bin collection events: %s", err)

--- a/custom_components/abc_council_bin_collection/config_flow.py
+++ b/custom_components/abc_council_bin_collection/config_flow.py
@@ -40,7 +40,7 @@ class BinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             
             # Validate the sanitized address: must be non-empty and numeric.
             if not sanitized_address or not sanitized_address.isdigit():
-                errors["user_address"] = "bin_collection_invalid_address"
+                errors["base"] = "invalid_address"
                 _LOGGER.error("Invalid address input: %s", address_input)
             else:
                 _LOGGER.debug("Creating entry with sanitized address: %s", sanitized_address)

--- a/custom_components/abc_council_bin_collection/config_flow.py
+++ b/custom_components/abc_council_bin_collection/config_flow.py
@@ -1,105 +1,151 @@
+"""
+Config flow for the ABC Council Bin Collection integration.
+
+Handles the user input for setting up the integration, including sanitation 
+and validation of the address. Also provides an options flow for changing
+data interval along with enabling/disabling calendar event creation feature.
+"""
+import logging
 import voluptuous as vol
+
+from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse, parse_qs
 from homeassistant import config_entries
 from homeassistant.core import callback
-from .const import DOMAIN, DEFAULT_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class BinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for the Bin Collection integration."""
+    """Handles config flow"""
     
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
-        """Handle the initial step where the user provides the address."""
-        errors = {}
+    async def async_step_user(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Handle the initial step where the user provides the address.
+        
+        If the provided address is a URL, it sanitizes and extracts the numeric address.
+        Returns a form for the user until valid data is entered.
+        """
+
+        errors: Dict[str, str] = {}
 
         if user_input is not None:
             address_input = user_input.get("user_address", "")
             sanitized_address = self._sanitize_address(address_input)
             
+            # Validate the sanitized address: must be non-empty and numeric.
             if not sanitized_address or not sanitized_address.isdigit():
-                errors["user_address"] = "invalid_address"
+                errors["user_address"] = "bin_collection_invalid_address"
                 _LOGGER.error("Invalid address input: %s", address_input)
             else:
-                _LOGGER.debug("Creating entry with address: %s", sanitized_address)
+                _LOGGER.debug("Creating entry with sanitized address: %s", sanitized_address)
                 return self.async_create_entry(
                     title="ABC Council Bin Collection",
                     data={"address": sanitized_address},
-                    options={}  # Ensure options are initialized
+                    options={}  # Ensure options are initialized.
                 )
 
         data_schema = vol.Schema({vol.Required("user_address"): str})
-        return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
 
     def _sanitize_address(self, address_input: str) -> str:
-        """Extract the numeric address if a full URL is provided."""
+        """
+        Extract and sanitize the numeric address if a full URL is provided.
+        
+        If the address starts with 'http(s)://', it attempts to extract the 'address'
+        parameter from the URL's query string.
+        """
+
+        address_input = address_input.strip()
         lower = address_input.lower()
         if lower.startswith("http://") or lower.startswith("https://"):
-            parsed_url = urlparse(address_input)
-            qs = parse_qs(parsed_url.query)
-            extracted = qs.get("address", [None])[0]
-            return extracted.strip() if extracted else ""
-        return address_input.strip()
+            try:
+                parsed_url = urlparse(address_input)
+                qs = parse_qs(parsed_url.query)
+                extracted = qs.get("address", [None])[0]
+                return extracted.strip() if extracted else ""
+            except Exception as ex:
+                _LOGGER.error("Error parsing URL '%s': %s", address_input, ex)
+                return ""
+        return address_input
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
-        """Get the options flow for the Bin Collection integration."""
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry) -> config_entries.OptionsFlow:
+        """Get the options flow for the Bin Collection integration"""
+
         return BinCollectionOptionsFlowHandler(config_entry)
 
-class BinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle options flow for the Bin Collection integration."""
 
-    def __init__(self, config_entry):
+class BinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle options flow for the Bin Collection integration"""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize the options configuration flow"""
+
         self._config_entry = config_entry
 
-    async def async_step_init(self, user_input=None):
-        """Manage the options flow."""
+    async def async_step_init(
+        self, user_input: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """
+        Manage the options flow for the integration.
+        """
+
         if user_input is not None:
-            # Normalize the calendar entity, can accept calendar.my_calendar or my_calendar
+            # Normalize the calendar entity: support inputs like "my_calendar" or "calendar.my_calendar".
             if "calendar_entity" in user_input:
                 value = user_input["calendar_entity"].strip()
                 if value and not value.startswith("calendar."):
                     value = f"calendar.{value}"
                 user_input["calendar_entity"] = value
 
-            _LOGGER.debug("User input received: %s", user_input)
+            _LOGGER.debug("User options received: %s", user_input)
             result = self.async_create_entry(title="", data=user_input)
-            
-            # Reload the integration upon saving options.
+
+            # Reload the integration on any options update to apply changes.
             await self.hass.config_entries.async_reload(self._config_entry.entry_id)
             return result
 
-        return self.async_show_form(step_id="init", data_schema=self._get_options_schema())
+        return self.async_show_form(
+            step_id="init", data_schema=self._get_options_schema()
+        )
 
-    def _get_options_schema(self):
-        """Define the schema for options, ensuring update_interval has a minimum value."""
+    def _get_options_schema(self) -> vol.Schema:
+        """
+        Define the options schema.
+        """
+
         return vol.Schema({
             vol.Required(
-                "update_interval", 
-                default=self._config_entry.options.get("update_interval", DEFAULT_UPDATE_INTERVAL)
-            ): vol.All(vol.Coerce(int), vol.Range(min=MIN_UPDATE_INTERVAL)),  # Enforce minimum
+                "update_interval",
+                default=self._config_entry.options.get("update_interval", DEFAULT_UPDATE_INTERVAL),
+            ): vol.All(vol.Coerce(int), vol.Range(min=MIN_UPDATE_INTERVAL)),
             vol.Required(
-                "create_calendar_events", 
-                default=self._config_entry.options.get("create_calendar_events", False)
+                "create_calendar_events",
+                default=self._config_entry.options.get("create_calendar_events", False),
             ): bool,
             vol.Optional(
-                "calendar_entity", 
-                default=self._config_entry.options.get("calendar_entity", "").strip()
+                "calendar_entity",
+                default=self._config_entry.options.get("calendar_entity", "").strip(),
             ): str,
             vol.Optional(
-                "summary_domestic", 
-                default=self._config_entry.options.get("summary_domestic", "Domestic Collections")
+                "summary_domestic",
+                default=self._config_entry.options.get("summary_domestic", "Domestic Collections"),
             ): str,
             vol.Optional(
-                "summary_recycling", 
-                default=self._config_entry.options.get("summary_recycling", "Recycling Collections")
+                "summary_recycling",
+                default=self._config_entry.options.get("summary_recycling", "Recycling Collections"),
             ): str,
             vol.Optional(
-                "summary_garden_food", 
-                default=self._config_entry.options.get("summary_garden_food", "Garden/Food Collections")
+                "summary_garden_food",
+                default=self._config_entry.options.get("summary_garden_food", "Garden/Food Collections"),
             ): str,
         })

--- a/custom_components/abc_council_bin_collection/const.py
+++ b/custom_components/abc_council_bin_collection/const.py
@@ -1,5 +1,57 @@
-DOMAIN = "abc_council_bin_collection"
-DEFAULT_UPDATE_INTERVAL = 96  # hours
-MIN_UPDATE_INTERVAL = 6       # hours
-EVENT_CREATION_DELAY = 30     # seconds
-DEFAULT_SENSOR_NAMES = ["Domestic Collections", "Recycling Collections", "Garden/Food Collections"]
+"""
+Constants for the ABC Council Bin Collection integration.
+
+This module defines all key constants used across the integration, 
+including domain identification, update intervals, event creation delays, 
+sensor names, and cleanup thresholds. Adjust these values as needed to 
+modify integration behavior.
+"""
+
+# ---------------------------------------------------------------------------
+# Domain and Metadata
+# ---------------------------------------------------------------------------
+DOMAIN: str = "abc_council_bin_collection"
+
+# Device metadata for consistency across entities
+DEVICE_NAME: str = "ABC Council Bin Collection"
+DEVICE_MANUFACTURER: str = "ABC Council"
+DEVICE_MODEL: str = "Bin Collection Sensor"
+DEVICE_VERSION: str = "1.0"
+DEVICE_INTEGRATION: str = "Home Assistant"
+
+# ---------------------------------------------------------------------------
+# Update Interval Constants (in hours)
+# ---------------------------------------------------------------------------
+# DEFAULT_UPDATE_INTERVAL:
+#   Number of hours between automatic data updates.
+DEFAULT_UPDATE_INTERVAL: int = 96  # hours
+
+# MIN_UPDATE_INTERVAL:
+#   Minimum allowed number of hours for an update interval to prevent excessive updates
+MIN_UPDATE_INTERVAL: int = 6  # hours
+
+# ---------------------------------------------------------------------------
+# Event Creation Constants
+# ---------------------------------------------------------------------------
+# EVENT_CREATION_DELAY:
+#   Delay (in seconds) before an event is created.
+EVENT_CREATION_DELAY: int = 20  # seconds
+
+# EVENT_CREATION_TIMEOUT:
+#   Delay (in seconds) between each calendar event creation
+EVENT_CREATION_TIMEOUT = 1 # seconds
+
+# ---------------------------------------------------------------------------
+# Sensor and Event Storage Constants
+# ---------------------------------------------------------------------------
+# DEFAULT_SENSOR_NAMES:
+#   A list of default sensor names used for bin collection events - do not change as change needs made to sensor.py
+DEFAULT_SENSOR_NAMES: list[str] = [
+    "Domestic Collections",
+    "Recycling Collections",
+    "Garden/Food Collections"
+]
+
+# EVENT_CLEANUP_THRESHOLD_DAYS:
+#   Number of days after which stored events are considered outdated and subject to cleanup.
+EVENT_CLEANUP_THRESHOLD_DAYS: int = 14  # days

--- a/custom_components/abc_council_bin_collection/coordinator.py
+++ b/custom_components/abc_council_bin_collection/coordinator.py
@@ -1,72 +1,134 @@
-from .const import EVENT_CREATION_DELAY
-import asyncio
-from datetime import datetime, timedelta
-import logging
-import re
-import async_timeout
-from bs4 import BeautifulSoup
+from __future__ import annotations
 
+import logging
+import asyncio
+import async_timeout
+
+from .const import EVENT_CREATION_DELAY, EVENT_CREATION_TIMEOUT
+from .storage import BinCollectionStorage
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+from bs4 import BeautifulSoup
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-_LOGGER = logging.getLogger(__name__)
+_LOGGER: logging.Logger = logging.getLogger(__name__)
 
-BIN_TYPES = {
+# Define types for clarity.
+BIN_TYPES: Dict[str, str] = {
     "bg-black": "Domestic Collections",
     "bg-green": "Recycling Collections",
     "bg-brown": "Garden/Food Collections",
 }
 
 class BinCollectionDataUpdateCoordinator(DataUpdateCoordinator):
-    """Manages fetching bin collection data and optionally creates calendar events."""
+    """
+    Manages fetching bin collection data and optionally creates calendar events
 
-    def __init__(self, hass, address, update_interval, create_calendar_events, calendar_entity, event_summaries):
-        """Initialize the coordinator."""
+    This coordinator is responsible for:
+      - Fetching and parsing HTML data from the bin collection website
+      - Managing persistent storage through BinCollectionStorage
+      - Creating calendar events if enabled
+    """
+
+    # DEBUG only - used for reducing calendar create event calls to avoid 403 errors
+    # VALID_DATES: set[str] = {"2025-05-20", "2025-05-27"}  # List of allowed dates
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        address: str,
+        update_interval: timedelta,
+        create_calendar_events: bool,
+        calendar_entity: str,
+        event_summaries: Dict[str, str],
+    ) -> None:
+        """
+        Initialise the coordinator
+
+        Args:
+            hass: Home Assistant instance.
+            address: The bin collection address (numeric).
+            update_interval: Update interval as a timedelta object.
+            create_calendar_events: Whether to create calendar events.
+            calendar_entity: The entity ID of the target calendar.
+            event_summaries: A mapping of bin types to event summary names.
+        """
         self.hass = hass
         self.address = address
         self.url = f"https://www.armaghbanbridgecraigavon.gov.uk/resident/binday-result/?address={self.address}"
         self.create_calendar_events = create_calendar_events
-        self.calendar_entity = calendar_entity  # already normalized in __init__.py
-        # event_summaries is used ONLY for calendar event creation.
-        self.event_summaries = event_summaries  
-        self._created_events = set()
+        self.calendar_entity = calendar_entity
+        self.event_summaries = event_summaries
+
+        # Initialize persistent storage.
+        self.storage: BinCollectionStorage = BinCollectionStorage(hass)
+
         super().__init__(hass, _LOGGER, name="Bin Collection Data", update_interval=update_interval)
 
-    async def _async_update_data(self):
-        """Fetch HTML data, parse it, and, if configured, create calendar events."""
-        for attempt in range(3):  # Retry mechanism
+    # DEBUG only - used for reducing calendar create event calls to avoid 403 errors
+    # def should_create_event(self, date_str: str) -> bool:
+    #     """Return True if provided date equals dates in VALID_DATES"""
+    #     return date_str in self.VALID_DATES
+
+    async def _async_update_data(self) -> Dict[str, List[str]]:
+        """
+        Fetch HTML data from the remote URL, process and parse bin collection dates,
+        and create calendar events (if enabled)
+
+        Returns:
+            A dictionary mapping collection types to lists of dates
+        """
+
+        await self.load_stored_events()
+
+        html: str = ""
+        # Tries 3 times before failure
+        for attempt in range(3):
             try:
-                async with async_timeout.timeout(30):
+                async with async_timeout.timeout(EVENT_CREATION_DELAY):
                     session = async_get_clientsession(self.hass)
                     response = await session.get(self.url)
                     response.raise_for_status()
                     html = await response.text()
-                break  # Exit loop on success
+                break
             except Exception as err:
                 _LOGGER.error("Error fetching data (attempt %d): %s", attempt + 1, err)
                 if attempt == 2:
-                    return {}  # Return empty data on failure
-        
+                    # Returning empty dict ensures we always return a dict
+                    return {}
+
         data = await self.hass.async_add_executor_job(self._parse_html, html)
 
+        # Create calendar events if enabled
         if self.create_calendar_events:
             if not self.calendar_entity:
-                _LOGGER.error("Calendar event creation is enabled but calendar_entity is empty. Skipping calendar event creation.")
+                _LOGGER.error("Calendar event creation is enabled but calendar_entity is empty. Skipping event creation.")
             else:
                 _LOGGER.info("Delaying calendar event creation by %s seconds...", EVENT_CREATION_DELAY)
                 await asyncio.sleep(EVENT_CREATION_DELAY)
                 await self._create_calendar_events(data)
 
-        return data
+        return data if data else {}
 
-    def _parse_html(self, html):
-        """Extract bin collection dates for each bin type from the HTML."""
-        result = {}
+    def _parse_html(self, html: str) -> Dict[str, List[str]]:
+        """
+        Parse the HTML content to extract bin collection dates.
+
+        Args:
+            html: The HTML content as a string.
+
+        Returns:
+            A dictionary with keys as bin collection types and values as lists of dates (in ISO format).
+        """
+
+        result: Dict[str, List[str]] = {}
         soup = BeautifulSoup(html, "html.parser")
 
         for class_name, default_title in BIN_TYPES.items():
             target_divs = soup.find_all("div", class_=class_name)
-            dates_list = []
+            dates_list: List[str] = []
 
             for target_div in target_divs:
                 sibling_div = target_div.find_parent().find_next_sibling("div")
@@ -75,51 +137,61 @@ class BinCollectionDataUpdateCoordinator(DataUpdateCoordinator):
                         date_text = h4.text.strip()
                         try:
                             date_obj = datetime.strptime(date_text, "%d/%m/%Y")
-                            formatted_date = date_obj.strftime("%Y-%m-%d")  # ISO 8601 format
-                            dates_list.append(formatted_date)  # Only the date, no weekday
+                            formatted_date = date_obj.strftime("%Y-%m-%d")  # ISO format
+                            dates_list.append(formatted_date)
                         except ValueError:
-                            _LOGGER.warning("Error parsing date: %s", date_text)
-                            dates_list.append(f"Error parsing date: {date_text}")
+                            _LOGGER.warning("Skipping invalid date format: %s", date_text)
                 else:
-                    dates_list.append(f"No sibling div found for class '{class_name}'.")
-            
-            result[default_title] = dates_list
+                    _LOGGER.warning("No sibling div found for bin type '%s'.", default_title)
 
-        _LOGGER.debug("Parsed bin collection data: %s", result)
+            result[default_title] = dates_list if dates_list else ["No collection scheduled"]
+
         return result
 
-    async def _create_calendar_events(self, data: dict):
-        """Create an all-day calendar event for each bin type and date."""
-        for bin_type, date_list in data.items():
-            for iso_start_date in date_list:  # Dates are already in YYYY-MM-DD format
+    async def load_stored_events(self) -> None:
+        """Load persistent bin collection events into memory"""
+        await self.storage.load_data()
+        # Optionally log loaded events for debugging:
+        _LOGGER.debug("Loaded stored events: %s", self.storage.data)
+
+    async def _create_calendar_events(self, data: Dict[str, List[str]]) -> None:
+        """
+        Create calendar events based on parsed data. Only creates events if they are not persistently stored.
+
+        Args:
+            data: A dictionary mapping bin types to lists of dates.
+        """
+
+        for bin_type, dates in data.items():
+            # Use user-defined summary if available.
+            summary_name = self.event_summaries.get(bin_type, bin_type)
+
+            for date in dates:
+                # DEBUG only - used for reducing calendar create event calls to avoid 403 errors
+                # Only allow creation for allowed dates.
+                # if not self.should_create_event(date):
+                #     continue
+
+                if date in self.storage.data and bin_type in self.storage.data[date]:
+                    _LOGGER.info("Skipping event creation for %s on %s — already stored.", summary_name, date)
+                    continue
+
+                event_data = {
+                    "entity_id": self.calendar_entity,
+                    "summary": summary_name,
+                    "start_date": date,
+                    "end_date": (datetime.strptime(date, "%Y-%m-%d") + timedelta(days=1)).strftime("%Y-%m-%d"),
+                    "description": "Automatic bin collection event."
+                }
+
                 try:
-                    dt = datetime.strptime(iso_start_date, "%Y-%m-%d").date()
-                    iso_end_date = (dt + timedelta(days=1)).strftime("%Y-%m-%d")
-                    event_key = f"{bin_type}-{iso_start_date}"
-                    
-                    if event_key in self._created_events:
-                        _LOGGER.debug("Skipping duplicate event creation for %s", event_key)
-                        continue
+                    await self.hass.services.async_call("calendar", "create_event", event_data)
+                    _LOGGER.info("Created event '%s' for %s", summary_name, date)
 
-                    # Use the event_summaries provided via options; fall back to the default bin type if not set.
-                    summary_name = self.event_summaries.get(bin_type, bin_type)
+                    # Store the event to prevent duplicate creation.
+                    await self.storage.store_event(date, bin_type)
 
-                    service_data = {
-                        "entity_id": self.calendar_entity,
-                        "summary": summary_name,
-                        "start_date": iso_start_date,
-                        "end_date": iso_end_date,
-                        "description": "Automatic bin collection event."
-                    }
-
-                    try:
-                        await self.hass.services.async_call(
-                            "calendar", "create_event", service_data, blocking=True
-                        )
-                        self._created_events.add(event_key)
-                        _LOGGER.info("Created calendar event for: %s", event_key)
-                    except Exception as ex:
-                        _LOGGER.error("Failed to create calendar event for %s: %s", event_key, ex)
-
+                    # Timeout till creating next event
+                    await asyncio.sleep(EVENT_CREATION_TIMEOUT)
                 except Exception as ex:
-                    _LOGGER.error("Error processing date %s for event creation: %s", iso_start_date, ex)
+                    _LOGGER.error("Failed to create calendar event for %s: %s", date, ex)

--- a/custom_components/abc_council_bin_collection/manifest.json
+++ b/custom_components/abc_council_bin_collection/manifest.json
@@ -13,6 +13,5 @@
     "beautifulsoup4>=4.9.0",
     "async-timeout>=3.0.0"
   ],
-  "supported_platforms": ["sensor", "button"],
   "version": "0.3.0"
 }

--- a/custom_components/abc_council_bin_collection/manifest.json
+++ b/custom_components/abc_council_bin_collection/manifest.json
@@ -1,14 +1,18 @@
 {
-    "domain": "abc_council_bin_collection",
-    "name": "ABC Council Bin Collection",
-    "codeowners": ["@jordanhinks"],
-    "config_flow": true,
-    "dependencies": [],
-    "documentation": "https://github.com/jordanhinks/abc_council_bin_collection",
-    "integration_type": "service",
-    "iot_class": "cloud_polling",
-    "issue_tracker": "https://github.com/jordanhinks/abc_council_bin_collection/issues",
-    "quality_scale": "bronze",
-    "requirements": ["beautifulsoup4>=4.9.0","async-timeout>=3.0.0"],
-    "version": "0.2.0"
-  }
+  "domain": "abc_council_bin_collection",
+  "name": "ABC Council Bin Collection",
+  "codeowners": ["@jordanhinks"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/jordanhinks/abc_council_bin_collection/blob/main/README.md",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/jordanhinks/abc_council_bin_collection/issues",
+  "quality_scale": "bronze",
+  "requirements": [
+    "beautifulsoup4>=4.9.0",
+    "async-timeout>=3.0.0"
+  ],
+  "supported_platforms": ["sensor", "button"],
+  "version": "0.3.0"
+}

--- a/custom_components/abc_council_bin_collection/sensor.py
+++ b/custom_components/abc_council_bin_collection/sensor.py
@@ -1,56 +1,99 @@
+"""
+Sensor platform for the ABC Council Bin Collection integration.
+
+This module defines sensor entities that report the next bin collection date 
+for a specific bin type. The data is provided by a DataUpdateCoordinator.
+"""
+
 import logging
 
-from homeassistant.components.sensor import SensorEntity
+from .const import DOMAIN, DEFAULT_SENSOR_NAMES, DEVICE_NAME, DEVICE_MANUFACTURER, DEVICE_MODEL
+from .coordinator import BinCollectionDataUpdateCoordinator
+from typing import Any, Dict, List, Optional
+from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.util import slugify
 
-from .const import DOMAIN, DEFAULT_SENSOR_NAMES
-from .coordinator import BinCollectionDataUpdateCoordinator
-
 _LOGGER = logging.getLogger(__name__)
 
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Any) -> None:
+    """Setup sensor entities platform"""
 
-async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities):
-    """Set up the sensor platform for the Bin Collection integration."""
     coordinator: BinCollectionDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    sensors = []
+    sensors: List[BinCollectionSensor] = []
     
-    # Create a sensor for each default sensor name.
+    # Create a sensor for each default sensor name
     for sensor_name in DEFAULT_SENSOR_NAMES:
         sensors.append(BinCollectionSensor(coordinator, sensor_name))
-    async_add_entities(sensors, True)
-
+    
+    async_add_entities(sensors, update_before_add=True)
+    _LOGGER.debug("Sensors for ABC Council Bin Collection successfully registered")
 
 class BinCollectionSensor(SensorEntity):
-    """Sensor representing bin collection dates for a specific bin type."""
+    """Sensor representing the bin collection dates for each bin type"""
 
-    def __init__(self, coordinator: BinCollectionDataUpdateCoordinator, sensor_name: str):
+    def __init__(self, coordinator: BinCollectionDataUpdateCoordinator, sensor_name: str) -> None:
+        """
+        Initialise the sensor
+
+        Args:
+            coordinator (BinCollectionDataUpdateCoordinator): Coordinator instance.
+            sensor_name (str): The name of the sensor (bin type).
+        """
+
         self.coordinator = coordinator
         self._sensor_name = sensor_name
-        
-        if sensor_name.endswith(" Collections"):
-            normalized = sensor_name[:-1]
-        else:
-            normalized = f"{sensor_name} Collection"
 
-        self._attr_name = normalized
-        self._attr_unique_id = f"{coordinator.address}_{slugify(normalized)}"
-        self._attr_state = "Unknown"
+        # Normalize the sensor name so that it is user friendly.
+        normalized_name = sensor_name if sensor_name.endswith(" Collections") else f"{sensor_name} Collection"
+        self._attr_name = normalized_name
+        self._attr_unique_id = f"{coordinator.address}_{slugify(normalized_name)}"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_state = "unknown"
 
-    async def async_added_to_hass(self):
-        """Register for coordinator updates."""
+    async def async_added_to_hass(self) -> None:
+        """Register for coordinator updates"""
+
         self.async_on_remove(self.coordinator.async_add_listener(self.async_write_ha_state))
 
     @property
-    def state(self):
-        """Return the next bin collection date for this sensor."""
-        dates = self.coordinator.data.get(self._sensor_name, [])
-        if dates:
-            return dates[0]
-        return "No Date"
+    def state(self) -> str:
+        """
+        Return sensor state
+
+        Retrieves the next bin collection date for this sensor type.
+        If no date is available, returns a default message.
+        """
+
+        if not self.coordinator.data:
+            _LOGGER.warning(
+                "Sensor %s could not retrieve data – coordinator data is missing or not updated.", self._sensor_name)
+            return "unavailable" #translation
+        dates: List[str] = self.coordinator.data.get(self._sensor_name, [])
+        return dates[0] if dates else "No collection scheduled" #translation
 
     @property
-    def extra_state_attributes(self):
-        """Return additional attributes with all dates."""
+    def extra_state_attributes(self) -> Dict[str, Any]:
+        """
+        Return additional attributes including all collection dates
+
+        These attributes can be used to display historical data or debugging info.
+        """
+
         return {"all_dates": self.coordinator.data.get(self._sensor_name, [])}
+
+    @property
+    def device_info(self) -> Optional[Dict[str, Any]]:
+        """
+        Return device info for the sensor for grouping in the device registry
+
+        This helps Home Assistant to know that this sensor is part of the bin collection integration.
+        """
+        
+        return {
+            "identifiers": {(DOMAIN, self.coordinator.address)},
+            "name": DEVICE_NAME,
+            "manufacturer": DEVICE_MANUFACTURER,
+            "model": DEVICE_MODEL,
+        }

--- a/custom_components/abc_council_bin_collection/storage.py
+++ b/custom_components/abc_council_bin_collection/storage.py
@@ -1,0 +1,123 @@
+"""
+Persistent storage module for the ABC Council Bin Collection integration.
+
+This module defines a BinCollectionStorage class that wraps Home Assistant’s 
+persistent storage helper to load, save, and manage bin collection event data.
+It automatically cleans out events older than a configured threshold.
+"""
+
+import logging
+import homeassistant.helpers.storage as storage
+
+from .const import EVENT_CLEANUP_THRESHOLD_DAYS
+from datetime import datetime, timedelta
+from typing import Any, Dict, List
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+class BinCollectionStorage:
+    """Handles persistent storage for bin collection events"""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the persistent storage helper"""
+
+        self.store = storage.Store(hass, 1, "bin_collection_events")
+        
+        # Storing events as a mapping from date strings to a list of event summaries
+        self.data: Dict[str, List[str]] = {}
+
+    async def load_data(self) -> None:
+        """
+        Load stored event dates and clean out outdated entries
+
+        Retrieves stored data from Home Assistant's storage and ensures that the data is 
+        a valid dictionary. It then calculates a cutoff date based on EVENT_CLEANUP_THRESHOLD_DAYS,
+        filtering out any events prior to that date and re-saving the cleaned data.
+        """
+
+        stored_data: Any = await self.store.async_load()
+        _LOGGER.debug("Retrieved stored bin events from persistent storage: %s", stored_data)
+
+        if stored_data:
+            # Ensure stored data is a valid dictionary; if not, reset it
+            if not isinstance(stored_data, dict):
+                _LOGGER.warning("Invalid storage format detected, resetting data.")
+                stored_data = {}
+
+            self.data = stored_data
+
+            # Calculate the cutoff date. Events older than this will be removed
+            cutoff_date = (datetime.today() - timedelta(days=EVENT_CLEANUP_THRESHOLD_DAYS)).strftime("%Y-%m-%d")
+            # Only keep event entries with keys (dates) more recent than the cutoff
+            cleaned_data = {date: events for date, events in self.data.items() if date > cutoff_date}
+
+            self.data = cleaned_data
+            await self.save_data()
+
+            _LOGGER.debug("Stored events after cleanup: %s", self.data)
+        else:
+            _LOGGER.debug("No stored bin collection events found.")
+
+    async def save_data(self) -> None:
+        """
+        Persist stored event dates
+
+        Uses Home Assistant's storage helper to save the current state of self.data.
+        """
+
+        _LOGGER.debug("Saving bin collection data to storage: %s", self.data)
+        await self.store.async_save(self.data)
+
+    def is_event_stored(self, date: str, summary: str) -> bool:
+        """
+        Determine whether a specific event is already stored
+        
+        Args:
+            date (str): The date of the event.
+            summary (str): A brief description of the event (e.g., bin type).
+
+        Returns:
+            bool: True if the event is already in storage, False otherwise.
+        """
+
+        stored_events: Any = self.data.get(date, [])
+
+        return isinstance(stored_events, list) and summary in stored_events
+
+    async def store_event(self, date: str, summary: str) -> None:
+        """
+        Persist a new event into storage
+
+        Args:
+            date (str): The date of the event.
+            summary (str): A description of the bin type or event summary.
+
+        If no list exists for a given date, one is created. The summary is then appended
+        only if it is not already present.
+        """
+
+        _LOGGER.debug("Adding event to storage: %s -> %s", date, summary)
+
+        if not isinstance(self.data.get(date), list):
+            # Ensure that the storage for this date is a list
+            self.data[date] = []
+
+        if summary not in self.data[date]:
+            self.data[date].append(summary)
+
+        await self.save_data()
+        _LOGGER.debug("Stored bin collection data after saving: %s", self.data)
+
+    async def clear_data(self) -> None:
+        """Clear all stored bin collection events"""
+        
+        if not self.data:
+            _LOGGER.debug("Attempted to clear bin events, but no data was found!")
+
+            return
+
+        _LOGGER.debug("Stored bin collection data before clearing: %s", self.data)
+        self.data.clear()
+        await self.save_data()
+        _LOGGER.debug("Stored bin collection data after clearing: %s", self.data)

--- a/custom_components/abc_council_bin_collection/translations/en.json
+++ b/custom_components/abc_council_bin_collection/translations/en.json
@@ -6,7 +6,10 @@
         "data": {
           "user_address": "Address"
         },
-        "description": "Enter your address as a numeric value or a URL containing it."
+        "description": "Enter complete URL or just address value.",
+        "error": {
+          "invalid_address": "Address provided is not valid. Please enter valid URL/address value."
+        }
       }
     }
   },
@@ -20,8 +23,19 @@
           "summary_domestic": "Domestic Collections Summary",
           "summary_recycling": "Recycling Collections Summary",
           "summary_garden_food": "Garden & Food Collections Summary"
-        }
+        },
+        "description": "Configure additional options relating to data fetch interval and creating calendar events."
       }
     }
+  },
+  "button": {
+    "clear_bin_events": "Clear Bin Events"
+  },
+  "sensor": {
+    "no_collection": "No collection scheduled",
+    "unavailable": "Unavailable"
+  },
+  "calendar": {
+    "event_created": "Automatic bin collection event."
   }
 }

--- a/custom_components/abc_council_bin_collection/translations/en.json
+++ b/custom_components/abc_council_bin_collection/translations/en.json
@@ -1,31 +1,31 @@
 {
-  "title": "ABC Council Bin Collection",
-  "config": {
-    "step": {
-      "user": {
-        "data": {
-          "user_address": "Address"
+    "title": "ABC Council Bin Collection",
+    "config": {
+        "step": {
+            "user": {
+                "data": {
+                    "user_address": "Address"
+                },
+                "description": "Enter complete URL or just address value."
+            }
         },
-        "description": "Enter complete URL or just address value.",
         "error": {
-          "invalid_address": "Address provided is not valid. Please enter valid URL/address value."
+            "invalid_address": "Address provided is not valid. Please enter valid URL/address value."
         }
-      }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "update_interval": "Update Interval (in hours)",
+                    "create_calendar_events": "Create Calendar Events",
+                    "calendar_entity": "Calendar Entity",
+                    "summary_domestic": "Domestic Collections Summary",
+                    "summary_recycling": "Recycling Collections Summary",
+                    "summary_garden_food": "Garden & Food Collections Summary"
+                },
+                "description": "Configure additional options relating to data fetch interval and creating calendar events."
+            }
+        }
     }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "update_interval": "Update Interval (in hours)",
-          "create_calendar_events": "Create Calendar Events",
-          "calendar_entity": "Calendar Entity",
-          "summary_domestic": "Domestic Collections Summary",
-          "summary_recycling": "Recycling Collections Summary",
-          "summary_garden_food": "Garden & Food Collections Summary"
-        },
-        "description": "Configure additional options relating to data fetch interval and creating calendar events."
-      }
-    }
-  }
 }

--- a/custom_components/abc_council_bin_collection/translations/en.json
+++ b/custom_components/abc_council_bin_collection/translations/en.json
@@ -27,15 +27,5 @@
         "description": "Configure additional options relating to data fetch interval and creating calendar events."
       }
     }
-  },
-  "button": {
-    "clear_bin_events": "Clear Bin Events"
-  },
-  "sensor": {
-    "no_collection": "No collection scheduled",
-    "unavailable": "Unavailable"
-  },
-  "calendar": {
-    "event_created": "Automatic bin collection event."
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,7 @@
     "name": "ABC Council Bin Collection",
     "content_in_root": false,
     "render_readme": true,
-    "country": "GB"
+    "country": "GB",
+    "domains": ["sensor", "button"],
+    "iot_class": "cloud_polling"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,5 @@
     "name": "ABC Council Bin Collection",
     "content_in_root": false,
     "render_readme": true,
-    "country": "GB",
-    "domains": ["sensor", "button"],
-    "iot_class": "cloud_polling"
+    "country": "GB"
 }


### PR DESCRIPTION
- Added ability for persistent storage with relation to calendar event creation - this provides a benefit where if integration is reloaded or Home Assistant is restarted; it then doesn't create further calendar events if one had previously been created.
- Added button entity to allow the clearing of persistent storage
- Changed integration to work in device format
- Cleaned up code in multiple files